### PR TITLE
Update chart to support latest min.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,15 +360,17 @@ $ helm install --set existingSecret=my-minio-secret minio/minio
 
 The following fields are expected in the secret:
 
-| .data.<key> in Secret      | Corresponding variable  | Description                                                                       |
-|:---------------------------|:------------------------|:----------------------------------------------------------------------------------|
-| `accesskey`                | `accessKey`             | Access key ID. Mandatory.                                                         |
-| `secretkey`                | `secretKey`             | Secret key. Mandatory.                                                            |
-| `gcs_key.json`             | `gcsgateway.gcsKeyJson` | GCS key if you are using the GCS gateway feature. Optional                        |
-| `awsAccessKeyId`           | `s3gateway.accessKey`   | S3 access key if you are using the S3 gateway feature. Optional                   |
-| `awsSecretAccessKey`       | `s3gateway.secretKey`   | S3 secret key if you are using the S3 gateway feature. Optional                   |
-| `etcd_client_cert.pem`     | `etcd.clientCert`       | Certificate for SSL/TLS connections to etcd. Optional                             |
-| `etcd_client_cert_key.pem` | `etcd.clientCertKey`    | Corresponding key for certificate above. Mandatory when etcd certificate defined. |
+| .data.<key> in Secret      | Corresponding variable        | Description                                                                       |
+|:---------------------------|:------------------------------|:----------------------------------------------------------------------------------|
+| `accesskey`                | `accessKey`                   | Access key ID. Mandatory.                                                         |
+| `secretkey`                | `secretKey`                   | Secret key. Mandatory.                                                            |
+| `gcs_key.json`             | `gcsgateway.gcsKeyJson`       | GCS key if you are using the GCS gateway feature. Optional                        |
+| `awsAccessKeyId`           | `s3gateway.accessKey`         | S3 access key if you are using the S3 gateway feature. Optional                   |
+| `awsSecretAccessKey`       | `s3gateway.secretKey`         | S3 secret key if you are using the S3 gateway feature. Optional                   |
+| `azureStorageAccount`      | `azuregateway.storageAccount` | Azure storage account if you are using the Azure gateway feature. Optional        |
+| `azureStorageKey   `       | `azuregateway.storageKey`     | Azure storage key if you are using the Azure gateway feature. Optional            |
+| `etcd_client_cert.pem`     | `etcd.clientCert`             | Certificate for SSL/TLS connections to etcd. Optional                             |
+| `etcd_client_cert_key.pem` | `etcd.clientCertKey`          | Corresponding key for certificate above. Mandatory when etcd certificate defined. |
 
 All corresponding variables will be ignored in values file.
 

--- a/minio/Chart.yaml
+++ b/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: High Performance, Kubernetes Native Object Storage
 name: minio
-version: 8.0.9
+version: 8.1.0
 appVersion: master
 keywords:
 - storage

--- a/minio/templates/deployment.yaml
+++ b/minio/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
           command:
             - "/bin/sh"
             - "-ce"
-            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway azure {{- template "minio.extraArgs" . }}"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway azure {{ .Values.azuregateway.serviceEndpoint }} {{- template "minio.extraArgs" . }}"
           {{- else }}
           {{- if .Values.gcsgateway.enabled }}
           command:
@@ -165,6 +165,22 @@ spec:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: awsSecretAccessKey
+            {{- end }}
+            {{- end }}
+            {{- if .Values.azuregateway.enabled -}}
+            {{- if or .Values.azuregateway.storageAccount .Values.existingSecret }}
+            - name: AZURE_STORAGE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: azureStorageAccount
+            {{- end }}
+            {{- if or .Values.azuregateway.storageKey .Values.existingSecret }}
+            - name: AZURE_STORAGE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: azureStorageKey
             {{- end }}
             {{- end }}
             {{- range $key, $val := .Values.environment }}

--- a/minio/templates/deployment.yaml
+++ b/minio/templates/deployment.yaml
@@ -117,12 +117,12 @@ spec:
             - name: {{ $scheme }}
               containerPort: 9000
           env:
-            - name: MINIO_ACCESS_KEY
+            - name: MINIO_ROOT_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: accesskey
-            - name: MINIO_SECRET_KEY
+            - name: MINIO_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}

--- a/minio/templates/post-install-prometheus-metrics-job.yaml
+++ b/minio/templates/post-install-prometheus-metrics-job.yaml
@@ -67,19 +67,19 @@ spec:
             - "-c"
             - mc --config-dir {{ .Values.configPathmc }} admin prometheus generate target --json --no-color -q > /workdir/mc.json
           env:
-            - name: MINIO_ACCESS_KEY
+            - name: MINIO_ROOT_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: accesskey
-            - name: MINIO_SECRET_KEY
+            - name: MINIO_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: secretkey
             #  mc admin prometheus generate don't really connect to remote server, TLS cert isn't required
             - name: MC_HOST_target
-              value: {{ $scheme }}://$(MINIO_ACCESS_KEY):$(MINIO_SECRET_KEY)@{{ $fullName }}:{{ .Values.service.port }}
+              value: {{ $scheme }}://$(MINIO_ROOT_USER):$(MINIO_ROOT_PASSWORD)@{{ $fullName }}:{{ .Values.service.port }}
           volumeMounts:
             - name: workdir
               mountPath: /workdir

--- a/minio/templates/secrets.yaml
+++ b/minio/templates/secrets.yaml
@@ -23,6 +23,14 @@ data:
   awsSecretAccessKey: {{ .Values.s3gateway.secretKey | toString | b64enc | quote }}
 {{- end }}
 {{- end }}
+{{- if .Values.azuregateway.enabled -}}
+{{- if .Values.azuregateway.storageAccount }}
+  azureStorageAccount: {{ .Values.azuregateway.storageAccount | toString | b64enc | quote }}
+{{- end }}
+{{- if .Values.azuregateway.storageKey }}
+  azureStorageKey: {{ .Values.azuregateway.storageKey | toString | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.etcd.clientCert }}
   etcd_client_cert.pem: {{ .Values.etcd.clientCert | toString | b64enc | quote }}
 {{- end }}

--- a/minio/templates/statefulset.yaml
+++ b/minio/templates/statefulset.yaml
@@ -109,12 +109,12 @@ spec:
             - name: {{ $scheme }}
               containerPort: 9000
           env:
-            - name: MINIO_ACCESS_KEY
+            - name: MINIO_ROOT_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: accesskey
-            - name: MINIO_SECRET_KEY
+            - name: MINIO_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}

--- a/minio/values.yaml
+++ b/minio/values.yaml
@@ -69,15 +69,17 @@ mountPath: "/export"
 
 ## Use existing Secret that store following variables:
 ##
-## | Chart var             | .data.<key> in Secret    |
-## |:----------------------|:-------------------------|
-## | accessKey             | accesskey                |
-## | secretKey             | secretkey                |
-## | gcsgateway.gcsKeyJson | gcs_key.json             |
-## | s3gateway.accessKey   | awsAccessKeyId           |
-## | s3gateway.secretKey   | awsSecretAccessKey       |
-## | etcd.clientCert       | etcd_client_cert.pem     |
-## | etcd.clientCertKey    | etcd_client_cert_key.pem |
+## | Chart var                   | .data.<key> in Secret    |
+## |:----------------------------|:-------------------------|
+## | accessKey                   | accesskey                |
+## | secretKey                   | secretkey                |
+## | gcsgateway.gcsKeyJson       | gcs_key.json             |
+## | s3gateway.accessKey         | awsAccessKeyId           |
+## | s3gateway.secretKey         | awsSecretAccessKey       |
+## | azuregateway.storageAccount | azureStorageAccount      |
+## | azuregateway.storageKey     | azureStorageKey          |
+## | etcd.clientCert             | etcd_client_cert.pem     |
+## | etcd.clientCertKey          | etcd_client_cert_key.pem |
 ##
 ## All mentioned variables will be ignored in values file.
 ## .data.accesskey and .data.secretkey are mandatory,
@@ -277,6 +279,9 @@ azuregateway:
   enabled: false
   # Number of parallel instances
   replicas: 4
+  serviceEndpoint: ""
+  storageAccount: ""
+  storageKey: ""
 
 ## Use minio as GCS (Google Cloud Storage) gateway, you should disable data persistence so no volume claim are created.
 ## https://docs.minio.io/docs/minio-gateway-for-gcs


### PR DESCRIPTION
Updated the credentials configuration to use MINIO_ROOT_USER/MINIO_ROOT_PASSWORD that appeared in 2021-01-05 build.

Added support for Azure gateway configuration:
```
azuregateway:
  serviceEndpoint: "https://mystorageaccount.blob.core.windows.net"
  storageAccount: "mystorageaccount"
  storageKey: "mystoragekey"
```